### PR TITLE
feat: addressing v2 — alias model, slot dependencies, bindings

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,0 +1,8 @@
+export interface Binding {
+  alias: string;
+  hub?: string;
+  hub_token?: string;
+  clip_token?: string;
+}
+
+export type Bindings = Record<string, Binding>;

--- a/src/clip.ts
+++ b/src/clip.ts
@@ -20,10 +20,9 @@ function isHandlerDef(value: unknown): value is HandlerDef {
 }
 
 export abstract class Clip {
-  abstract name: string;
   abstract domain: string;
   abstract patterns: string[];
-  dependencies: string[] = [];
+  dependencies: Record<string, { package: string; version: string }> = {};
   entities: Record<string, z.ZodObject<any>> = {};
 
   protected readonly commands = new Map<string, HandlerDef>();
@@ -102,8 +101,9 @@ export abstract class Clip {
   }
 
   printHelp(): string {
+    const name = getClipName(this);
     const lines: string[] = [
-      `${this.name} (${this.domain})`,
+      name ? `${name} (${this.domain})` : this.domain,
       "",
     ];
 
@@ -187,4 +187,9 @@ export abstract class Clip {
       clip.commandDescriptions.set(propertyKey, describe);
     }
   }
+}
+
+export function getClipName(clip: Clip): string | undefined {
+  const value = (clip as { name?: unknown }).name;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,5 +1,5 @@
 import { dirname, join, resolve, sep } from "node:path";
-import type { Clip } from "./clip";
+import { getClipName, type Clip } from "./clip";
 import { zodToManifestType } from "./manifest";
 
 const CORS_HEADERS = {
@@ -249,5 +249,5 @@ export async function serveHTTP(clip: Clip, port = 3000): Promise<void> {
     fetch: (request) => handleRequest(clip, request),
   });
 
-  console.error(`Clip "${clip.name}" running at http://localhost:${server.port}`);
+  console.error(`Clip "${getClipName(clip) ?? clip.constructor.name}" running at http://localhost:${server.port}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 export { Clip } from "./clip";
+export type { Binding, Bindings } from "./bindings";
 export { command } from "./command";
 export { handler, type HandlerDef, type Stream } from "./handler";
 export { serveHTTP } from "./http";
 export { serveIPC, invoke, redirectConsoleToStderr } from "./ipc";
+export type { IPCManifest } from "./manifest";
 export { serveMCP } from "./mcp";
 export { z } from "zod";

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
+import type { Binding, Bindings } from "./bindings";
 import type { Clip } from "./clip";
 import type { Stream } from "./handler";
-import { createIPCManifest } from "./manifest";
+import { createIPCManifest, type IPCManifest } from "./manifest";
 
 // === IPC Protocol Types ===
 
@@ -14,7 +17,12 @@ interface BaseMessage {
 
 interface RegisterMessage extends BaseMessage {
   type: "register";
-  manifest: { name: string; domain: string; commands: string[]; dependencies: string[] };
+  manifest: IPCManifest;
+}
+
+interface RegisteredMessage extends BaseMessage {
+  type: "registered";
+  alias?: string;
 }
 
 interface InvokeMessage extends BaseMessage {
@@ -23,6 +31,9 @@ interface InvokeMessage extends BaseMessage {
   command?: string;
   clip?: string;
   input?: unknown;
+  hub?: string;
+  hub_token?: string;
+  clip_token?: string;
 }
 
 interface ResultMessage extends BaseMessage {
@@ -52,6 +63,68 @@ interface DoneMessage extends BaseMessage {
 
 const pendingInvokes = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
 let idCounter = 0;
+let registeredAlias: string | undefined;
+const bindings = loadBindings();
+
+function loadBindings(): Bindings {
+  const bindingsPath = join(dirname(Bun.main), "bindings.json");
+
+  try {
+    const parsed = JSON.parse(readFileSync(bindingsPath, "utf8")) as unknown;
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const loadedBindings: Bindings = {};
+    for (const [slot, value] of Object.entries(parsed)) {
+      const binding = normalizeBinding(value);
+      if (binding) {
+        loadedBindings[slot] = binding;
+      }
+    }
+
+    return loadedBindings;
+  } catch {
+    return {};
+  }
+}
+
+function normalizeBinding(value: unknown): Binding | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const alias = asNonEmptyString(candidate.alias);
+
+  if (!alias) {
+    return null;
+  }
+
+  const binding: Binding = { alias };
+  const hub = asNonEmptyString(candidate.hub);
+  const hubToken = asNonEmptyString(candidate.hub_token);
+  const clipToken = asNonEmptyString(candidate.clip_token);
+
+  if (hub) {
+    binding.hub = hub;
+  }
+
+  if (hubToken) {
+    binding.hub_token = hubToken;
+  }
+
+  if (clipToken) {
+    binding.clip_token = clipToken;
+  }
+
+  return binding;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 
 function nextId(): string {
   return `c${++idCounter}`;
@@ -63,11 +136,22 @@ function send(msg: Record<string, unknown>): void {
 
 // === Public API ===
 
-export async function invoke(clip: string, command: string, input: unknown): Promise<unknown> {
+export async function invoke(slot: string, command: string, input: unknown): Promise<unknown> {
+  const binding = bindings[slot];
   const id = nextId();
+
   return new Promise((resolve, reject) => {
     pendingInvokes.set(id, { resolve, reject });
-    send({ id, type: "invoke", clip, command, input });
+    send({
+      id,
+      type: "invoke",
+      clip: binding?.alias ?? slot,
+      command,
+      input,
+      hub: binding?.hub,
+      hub_token: binding?.hub_token,
+      clip_token: binding?.clip_token,
+    });
   });
 }
 
@@ -112,7 +196,7 @@ export async function serveIPC(clip: Clip): Promise<void> {
 
     switch (msg.type) {
       case "registered":
-        // Registration confirmed
+        registeredAlias = asNonEmptyString((msg as RegisteredMessage).alias);
         break;
 
       case "invoke": {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,14 +1,13 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { z, type ZodType } from "zod";
-import type { Clip } from "./clip";
+import { getClipName, type Clip } from "./clip";
 
 export interface IPCManifest {
-  name: string;
   domain: string;
   description?: string;
   commands: string[];
-  dependencies: string[];
+  dependencies: Record<string, { package: string; version: string }>;
   package?: string;
   version?: string;
 }
@@ -99,11 +98,8 @@ export function zodToManifestType(schema: ZodType): string {
 }
 
 export function generateManifest(clip: Clip): string {
-  const lines = [
-    `Clip: ${clip.name}`,
-    `Domain: ${clip.domain}`,
-    "",
-  ];
+  const name = getClipName(clip);
+  const lines = name ? [`Clip: ${name}`, `Domain: ${clip.domain}`, ""] : [`Domain: ${clip.domain}`, ""];
 
   if (clip.patterns.length > 0) {
     lines.push("Patterns:");
@@ -188,7 +184,6 @@ export function createIPCManifest(clip: Clip): IPCManifest {
   const pkgInfo = resolvePackageInfo();
 
   return {
-    name: clip.name,
     domain: clip.domain,
     commands: Array.from(clip.getCommands().keys()),
     dependencies: clip.dependencies,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,13 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { Clip } from "./clip";
+import { getClipName, type Clip } from "./clip";
 import { redirectConsoleToStderr } from "./ipc";
 
 export async function serveMCP(clip: Clip): Promise<void> {
   // Redirect console.log to stderr so stdout is reserved for MCP JSON-RPC
   redirectConsoleToStderr();
   const server = new McpServer({
-    name: clip.name,
+    name: getClipName(clip) ?? clip.constructor.name,
     version: "1.0.0",
   });
 


### PR DESCRIPTION
## Summary
- Remove `abstract name` from Clip base class (alias assigned by Hub)
- Dependencies changed to slot model: `Record<string, {package, version}>`
- Add bindings.json support: SDK reads at startup, resolves slots to aliases
- `invoke()` resolves slot → binding → alias + hub + tokens
- IPC register manifest no longer includes name
- IPC registered response reads alias from Hub
- IPC invoke supports cross-hub fields: hub, hub_token, clip_token

## Part of
epiral/pinix#29

## Test plan
- [ ] Existing Clips (clip-todo, agent-clip) still compile and register
- [ ] bindings.json loading with missing file, empty file, valid bindings
- [ ] invoke() slot resolution with and without bindings
- [ ] Cross-hub invoke fields in IPC message

🤖 Generated with [Claude Code](https://claude.com/claude-code)