### PR TITLE
feat: auto-generate JSON Schema for command input/output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@ export { command } from "./command";
 export { handler, type HandlerDef, type Stream } from "./handler";
 export { serveHTTP } from "./http";
 export { serveIPC, invoke, redirectConsoleToStderr } from "./ipc";
-export type { IPCManifest } from "./manifest";
+export type { IPCCommandInfo, IPCManifest } from "./manifest";
 export { serveMCP } from "./mcp";
 export { z } from "zod";

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,10 +3,17 @@ import { dirname, join } from "node:path";
 import { z, type ZodType } from "zod";
 import { getClipName, type Clip } from "./clip";
 
+export interface IPCCommandInfo {
+  name: string;
+  description?: string;
+  input?: string;
+  output?: string;
+}
+
 export interface IPCManifest {
   domain: string;
   description?: string;
-  commands: string[];
+  commands: IPCCommandInfo[];
   dependencies: Record<string, { package: string; version: string }>;
   package?: string;
   version?: string;
@@ -183,9 +190,26 @@ function asString(value: unknown): string | undefined {
 export function createIPCManifest(clip: Clip): IPCManifest {
   const pkgInfo = resolvePackageInfo();
 
+  const commands: IPCCommandInfo[] = [];
+
+  for (const [name, handler] of clip.getCommands()) {
+    const description = clip.getCommandDescription(name);
+    const cmd: IPCCommandInfo = { name };
+    if (description) cmd.description = description;
+
+    try {
+      cmd.input = JSON.stringify(z.toJSONSchema(handler.input));
+    } catch {}
+    try {
+      cmd.output = JSON.stringify(z.toJSONSchema(handler.output));
+    } catch {}
+
+    commands.push(cmd);
+  }
+
   return {
     domain: clip.domain,
-    commands: Array.from(clip.getCommands().keys()),
+    commands,
     dependencies: clip.dependencies,
     ...pkgInfo,
   };


### PR DESCRIPTION
## Summary
- `IPCManifest.commands` changed from `string[]` to `IPCCommandInfo[]`
- Each command now includes `input` and `output` JSON Schema strings
- Uses Zod v4 built-in `z.toJSONSchema()` — no new dependencies
- Schema conversion failures silently caught (never blocks registration)

## Verified
```
list: input schema type=object, props=[]
add:  input schema type=object, props=[title]
delete: input schema type=object, props=[id]
```

Part of epiral/pinix#39

🤖 Generated with [Claude Code](https://claude.com/claude-code)