### PR TITLE
feat: commandGroup() sub-command support

### DIFF
--- a/src/clip.ts
+++ b/src/clip.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { CLIHelpError, formatCLIHelp, parseCLIArgs } from "./cli";
 import type { HandlerDef } from "./handler";
+import { isGroupDef } from "./handler";
 import { serveHTTP } from "./http";
 import { serveIPC } from "./ipc";
 import { serveMCP } from "./mcp";
@@ -35,6 +36,7 @@ export abstract class Clip {
 
   protected readonly commands = new Map<string, HandlerDef>();
   protected readonly commandDescriptions = new Map<string, string>();
+  protected readonly commandGroups = new Map<string, string>();
 
   async start(): Promise<void> {
     const args = process.argv.slice(2);
@@ -75,14 +77,21 @@ export abstract class Clip {
       return;
     }
 
-    const commandName = modeOrCommand;
-    const commandHandler = this.commands.get(commandName);
+    // Resolve command: collect non-flag tokens as command path, greedy match longest
+    const { commandName, commandArgs } = this.resolveCommand(args);
 
-    if (!commandHandler) {
-      console.error(`Unknown command: ${commandName}`);
+    if (!commandName) {
+      // Check if first token is a group name → show group help
+      if (this.commandGroups.has(modeOrCommand)) {
+        console.log(this.printGroupHelp(modeOrCommand));
+        return;
+      }
+      console.error(`Unknown command: ${modeOrCommand}`);
       console.log(this.printHelp());
       return;
     }
+
+    const commandHandler = this.commands.get(commandName)!;
 
     if (!(commandHandler.input instanceof z.ZodObject)) {
       console.error(`CLI mode only supports object input schemas for command: ${commandName}`);
@@ -90,13 +99,12 @@ export abstract class Clip {
     }
 
     try {
-      const input = parseCLIArgs(restArgs, commandHandler.input);
+      const input = parseCLIArgs(commandArgs, commandHandler.input);
       const output = await commandHandler.fn(input, "");
       let parsedOutput: unknown;
       try {
         parsedOutput = commandHandler.output.parse(output);
       } catch {
-        // Fallback: output schema validation failed (e.g. ZodRecord with missing valueType in Zod v4)
         parsedOutput = output;
       }
       console.log(JSON.stringify(parsedOutput));
@@ -108,6 +116,40 @@ export abstract class Clip {
 
       console.error(error instanceof Error ? error.message : String(error));
     }
+  }
+
+  private resolveCommand(args: string[]): { commandName: string | null; commandArgs: string[] } {
+    // Collect non-flag tokens as potential command path
+    const cmdParts: string[] = [];
+    let flagStart = args.length;
+
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i]!;
+      if (arg.startsWith("-")) {
+        flagStart = i;
+        break;
+      }
+      cmdParts.push(arg);
+    }
+
+    const remainingArgs = args.slice(flagStart);
+
+    // Greedy: try longest match first
+    for (let len = cmdParts.length; len > 0; len--) {
+      const candidate = cmdParts.slice(0, len).join(" ");
+      if (this.commands.has(candidate)) {
+        // Unused command tokens become part of args (shouldn't happen with one-level nesting)
+        const extra = cmdParts.slice(len);
+        return { commandName: candidate, commandArgs: [...extra, ...remainingArgs] };
+      }
+    }
+
+    // Check if it's "group --help"
+    if (cmdParts.length > 0 && this.commandGroups.has(cmdParts[0]!) && remainingArgs.includes("--help")) {
+      return { commandName: null, commandArgs: [] };
+    }
+
+    return { commandName: null, commandArgs: [] };
   }
 
   toManifest(): string {
@@ -144,7 +186,20 @@ export abstract class Clip {
       return lines.join("\n");
     }
 
+    // Separate top-level commands from grouped commands
+    const groupedCommands = new Set<string>();
+    for (const groupName of this.commandGroups.keys()) {
+      for (const cmdName of this.commands.keys()) {
+        if (cmdName.startsWith(`${groupName} `)) {
+          groupedCommands.add(cmdName);
+        }
+      }
+    }
+
+    // Print top-level commands first
     for (const [commandName, commandHandler] of this.commands) {
+      if (groupedCommands.has(commandName)) continue;
+
       const describe = this.commandDescriptions.get(commandName);
       lines.push(`  ${commandName}${describe ? ` - ${describe}` : ""}`);
 
@@ -153,6 +208,45 @@ export abstract class Clip {
         lines.push(...commandHelp.split("\n").map((line) => `    ${line}`));
       } else {
         lines.push(`    Input: ${commandHandler.input.constructor.name}`);
+      }
+    }
+
+    // Print groups with sub-commands
+    for (const [groupName, groupDesc] of this.commandGroups) {
+      lines.push(`  ${groupName} - ${groupDesc}`);
+      for (const [commandName, commandHandler] of this.commands) {
+        if (!commandName.startsWith(`${groupName} `)) continue;
+        const subName = commandName.slice(groupName.length + 1);
+        const describe = this.commandDescriptions.get(commandName);
+        lines.push(`    ${subName}${describe ? ` - ${describe}` : ""}`);
+
+        if (commandHandler.input instanceof z.ZodObject) {
+          const commandHelp = formatCLIHelp(commandHandler.input);
+          lines.push(...commandHelp.split("\n").map((line) => `      ${line}`));
+        }
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  private printGroupHelp(groupName: string): string {
+    const groupDesc = this.commandGroups.get(groupName);
+    const lines: string[] = [
+      `${groupName}${groupDesc ? ` - ${groupDesc}` : ""}`,
+      "",
+      "Sub-commands:",
+    ];
+
+    for (const [commandName, commandHandler] of this.commands) {
+      if (!commandName.startsWith(`${groupName} `)) continue;
+      const subName = commandName.slice(groupName.length + 1);
+      const describe = this.commandDescriptions.get(commandName);
+      lines.push(`  ${subName}${describe ? ` - ${describe}` : ""}`);
+
+      if (commandHandler.input instanceof z.ZodObject) {
+        const commandHelp = formatCLIHelp(commandHandler.input);
+        lines.push(...commandHelp.split("\n").map((line) => `    ${line}`));
       }
     }
 
@@ -165,6 +259,10 @@ export abstract class Clip {
 
   getCommandDescription(name: string): string | undefined {
     return this.commandDescriptions.get(name);
+  }
+
+  getCommandGroups(): ReadonlyMap<string, string> {
+    return this.commandGroups;
   }
 
   protected printCommandHelp(commandName: string, commandHandler: HandlerDef): string {
@@ -191,8 +289,18 @@ export abstract class Clip {
     const clip = target as Clip;
     const value = (clip as unknown as Record<string, unknown>)[propertyKey];
 
+    if (isGroupDef(value)) {
+      clip.commandGroups.set(propertyKey, value.description);
+      for (const [subName, sub] of Object.entries(value.commands)) {
+        const fullName = `${propertyKey} ${subName}`;
+        clip.commands.set(fullName, sub.handler);
+        clip.commandDescriptions.set(fullName, sub.description);
+      }
+      return;
+    }
+
     if (!isHandlerDef(value)) {
-      throw new Error(`@command can only decorate handler() fields: ${propertyKey}`);
+      throw new Error(`@command can only decorate handler() or commandGroup() fields: ${propertyKey}`);
     }
 
     clip.commands.set(propertyKey, value);

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,4 @@
-import type { HandlerDef } from "./handler";
+import type { GroupDef, HandlerDef } from "./handler";
 
 interface CommandRegistrar {
   _registerCommand(target: object, propertyKey: string, describe?: string): void;
@@ -7,7 +7,7 @@ interface CommandRegistrar {
 export function command(describe?: string) {
   return function <This extends object>(
     _value: undefined,
-    context: ClassFieldDecoratorContext<This, HandlerDef>,
+    context: ClassFieldDecoratorContext<This, HandlerDef | GroupDef>,
   ): void {
     if (context.static) {
       throw new Error("@command can only be used on instance fields");

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,3 +24,35 @@ export function handler<I extends ZodType, O extends ZodType>(
     },
   };
 }
+
+// === Command Groups (sub-commands) ===
+
+export interface SubcommandDef {
+  description: string;
+  handler: HandlerDef;
+}
+
+export interface GroupDef {
+  __type: "group";
+  description: string;
+  commands: Record<string, SubcommandDef>;
+}
+
+export function isGroupDef(value: unknown): value is GroupDef {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as GroupDef).__type === "group"
+  );
+}
+
+export function commandGroup(
+  description: string,
+  commands: Record<string, [string, HandlerDef]>,
+): GroupDef {
+  const mapped: Record<string, SubcommandDef> = {};
+  for (const [name, [desc, h]] of Object.entries(commands)) {
+    mapped[name] = { description: desc, handler: h };
+  }
+  return { __type: "group", description, commands: mapped };
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -136,7 +136,7 @@ function listCommands(clip: Clip): Response {
     name,
     description: clip.getCommandDescription(name) ?? null,
     method: "POST",
-    path: `/api/${name}`,
+    path: `/api/${name.replace(/ /g, "/")}`,
     input: zodToManifestType(commandHandler.input),
     output: zodToManifestType(commandHandler.output),
   }));
@@ -282,11 +282,14 @@ async function handleRequest(clip: Clip, request: Request): Promise<Response> {
       return errorResponse("Method not allowed", 405);
     }
 
-    const commandName = pathname.slice("/api/".length);
+    const rawCommand = pathname.slice("/api/".length);
 
-    if (commandName.length === 0 || commandName.includes("/")) {
+    if (rawCommand.length === 0) {
       return errorResponse("Unknown command", 404);
     }
+
+    // Map URL path segments to space-separated command name: /api/schema/list → "schema list"
+    const commandName = decodeURIComponent(rawCommand).replace(/\//g, " ");
 
     return handleCommandRequest(clip, commandName, request);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { Clip } from "./clip";
 export type { Binding, Bindings } from "./bindings";
 export { command } from "./command";
-export { handler, type HandlerDef, type Stream } from "./handler";
+export { handler, commandGroup, type HandlerDef, type GroupDef, type Stream } from "./handler";
 export { serveHTTP } from "./http";
 export { hubInvoke, hubListClips } from "./hub";
 export { serveIPC, invoke, invokeClip, listClips, redirectConsoleToStderr } from "./ipc";

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -17,6 +17,7 @@ export interface IPCManifest {
   dependencies: Record<string, { package: string; version: string }>;
   patterns?: string[];
   entities?: Record<string, unknown>;
+  groups?: Record<string, { description: string }>;
   package?: string;
   version?: string;
 }
@@ -144,22 +145,50 @@ export function generateManifest(clip: Clip): string {
   lines.push("Commands:");
 
   const commands = Array.from(clip.getCommands().entries());
+  const groups = clip.getCommandGroups();
 
   if (commands.length === 0) {
     lines.push("- none");
     return lines.join("\n");
   }
 
-  for (const [name, handler] of commands) {
-    lines.push(`- ${name}`);
+  // Collect grouped command names
+  const groupedCommands = new Set<string>();
+  for (const groupName of groups.keys()) {
+    for (const [cmdName] of commands) {
+      if (cmdName.startsWith(`${groupName} `)) {
+        groupedCommands.add(cmdName);
+      }
+    }
+  }
 
+  // Top-level commands
+  for (const [name, handler] of commands) {
+    if (groupedCommands.has(name)) continue;
+
+    lines.push(`- ${name}`);
     const describe = clip.getCommandDescription(name);
     if (describe) {
       lines.push(`  Description: ${describe}`);
     }
-
     lines.push(`  Input: ${zodToManifestType(handler.input)}`);
     lines.push(`  Output: ${zodToManifestType(handler.output)}`);
+  }
+
+  // Groups with sub-commands
+  for (const [groupName, groupDesc] of groups) {
+    lines.push(`- ${groupName} (${groupDesc})`);
+    for (const [name, handler] of commands) {
+      if (!name.startsWith(`${groupName} `)) continue;
+      const subName = name.slice(groupName.length + 1);
+      lines.push(`  - ${subName}`);
+      const describe = clip.getCommandDescription(name);
+      if (describe) {
+        lines.push(`    Description: ${describe}`);
+      }
+      lines.push(`    Input: ${zodToManifestType(handler.input)}`);
+      lines.push(`    Output: ${zodToManifestType(handler.output)}`);
+    }
   }
 
   return lines.join("\n");
@@ -226,6 +255,15 @@ export function createIPCManifest(clip: Clip): IPCManifest {
 
   if (clip.patterns.length > 0) {
     manifest.patterns = clip.patterns;
+  }
+
+  const groupEntries = clip.getCommandGroups();
+  if (groupEntries.size > 0) {
+    const groups: Record<string, { description: string }> = {};
+    for (const [name, description] of groupEntries) {
+      groups[name] = { description };
+    }
+    manifest.groups = groups;
   }
 
   const entityEntries = Object.entries(clip.entities);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,9 +13,10 @@ export async function serveMCP(clip: Clip): Promise<void> {
 
   for (const [name, commandHandler] of clip.getCommands()) {
     const description = clip.getCommandDescription(name);
+    const toolName = name.replace(/ /g, "_");
 
     server.registerTool(
-      name,
+      toolName,
       {
         description,
         inputSchema: commandHandler.input,


### PR DESCRIPTION
## Summary

- Add `commandGroup()` API for declaring hierarchical sub-commands in Clips
- `@command` decorator now accepts both `HandlerDef` and `GroupDef`
- Commands stored as space-separated names internally (e.g. `"schema list"`)
- Each protocol adapts: CLI spaces, MCP underscores, HTTP path segments (`/api/schema/list`)
- `printHelp()` and text manifest display sub-commands grouped under parent
- IPC manifest includes optional `groups` field with group descriptions

## Usage

```typescript
@command()
schema = commandGroup("Schema management", {
  list: ["List all schemas", handler(inputZ, outputZ, fn)],
  get:  ["Get schema definition", handler(inputZ, outputZ, fn)],
});
```

CLI: `bun run clip.ts schema list --topLevel true`

## Test plan

- [x] Smoke test: commands map, groups map, descriptions all correct
- [x] CLI invocation: `schema list`, `schema get --type meeting`, `root`
- [x] `--help`: global help shows groups, `schema --help` shows sub-commands, `schema list --help` shows params
- [x] `--manifest`: text manifest groups sub-commands
- [x] Backward compatible: existing clips without commandGroup work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)